### PR TITLE
double active_support require causes error with rails 4

### DIFF
--- a/lib/sidekiq/throttler.rb
+++ b/lib/sidekiq/throttler.rb
@@ -1,6 +1,5 @@
 require 'sidekiq'
-require 'active_support'
-require 'active_support/core_ext'
+require 'active_support/core_ext/numeric/time'
 
 require 'sidekiq/throttler/version'
 require 'sidekiq/throttler/rate_limit'


### PR DESCRIPTION
I've changed it to only require the part of ActiveSupport that's actually used.
