### PR TITLE
Fix bad message setup.

### DIFF
--- a/spec/sidekiq/throttler_spec.rb
+++ b/spec/sidekiq/throttler_spec.rb
@@ -16,7 +16,7 @@ describe Sidekiq::Throttler do
 
   let(:message) do
     {
-      args: 'Clint Eastwood'
+      'args' => 'Clint Eastwood'
     }
   end
 


### PR DESCRIPTION
Message setup in the test was using symbols for the args key, but, the tests themselves
were using a string as the key.

Note that the tests were passing before because there was an empty message being sent. 

This doesn't seem to break anything, but, the spec was not using (what I think is) the intended message value, and therefore wasn't really testing what it was meant to.
