### PR TITLE
Add options: to not enqueue if already scheduled / throttle on arguments match

### DIFF
--- a/lib/sidekiq/throttler.rb
+++ b/lib/sidekiq/throttler.rb
@@ -37,7 +37,9 @@ module Sidekiq
       end
 
       rate_limit.exceeded do |delay|
-        worker.class.perform_in(delay, *msg['args'])
+        unless rate_limit.scheduled?
+          worker.class.perform_in(delay, *msg['args'])
+        end
       end
 
       rate_limit.execute

--- a/lib/sidekiq/throttler/rate_limit.rb
+++ b/lib/sidekiq/throttler/rate_limit.rb
@@ -113,6 +113,15 @@ module Sidekiq
         count >= threshold
       end
 
+      # Check if the same worker with args is already in the queue
+      def scheduled?
+        if options['scheduled_unique']
+          Sidekiq::ScheduledSet.new.select{|job| job.klass == worker.class.to_s && job.args == payload}.any?
+        else
+          false
+        end
+      end
+
       ##
       # Check if rate limit is within the threshold.
       #

--- a/lib/sidekiq/throttler/rate_limit.rb
+++ b/lib/sidekiq/throttler/rate_limit.rb
@@ -121,18 +121,7 @@ module Sidekiq
       # Check if the same worker with args is already in the queue
       def scheduled?
         if options['scheduled_unique']
-          same_jobs = Sidekiq::ScheduledSet.new.select do |job|
-            if job.klass == worker.class.to_s
-              if options['unique_args']
-                job.args == payload
-              else
-                true
-              end
-            else
-              false
-            end
-          end
-          same_jobs.any?
+          Sidekiq::ScheduledSet.new.select{ |job| job.klass == worker.class.to_s &&  job.args == payload}.any?
         else
           false
         end


### PR DESCRIPTION
## Avoid flood of the Scheduled queue

The problem is when you have lot of jobs performing the same operation, you don't want to flood the scheduled queue and just keep one of these (same) jobs.
Set option 'scheduled_unique' to true to activate it.
The unicity is checked on worker class name and worker arguments. (could be improved perhaps)
## Be able to throttle if arguments match

New option `unique_args`, if set to `true` the throttle will be applied to jobs with the same arguments.
