### PR TITLE
Allow jobs not to be rescheduled upon exceeding the threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ minutes. However, on Tuesdays limit jobs to 9 thousand every *15 minutes*:
 sidekiq_options throttle: { threshold: 9000, period: ->{ Date.today.tuesday? ? 15.minutes : 10.minutes } }
 ```
 
+### Do Not Reschedule Throttled Jobs
+
+By default, if a job is throttled, it will be rescheduled and tried again after a delay equal to the value of the worker's `period` setting. In some cases, you may not want throttled jobs to be rescheduled at all. In this case, you can set `reschedule: false` in the worker's options hash, like so:
+
+```ruby
+class NoRescheduleWorker
+  include Sidekiq::Worker
+
+  sidekiq_options throttle: { threshold: 10, period: 1.minute, reschedule: false }
+
+  def perform; end
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/sidekiq/throttler.rb
+++ b/lib/sidekiq/throttler.rb
@@ -4,6 +4,7 @@ require 'singleton'
 
 require 'sidekiq/throttler/version'
 require 'sidekiq/throttler/rate_limit'
+require 'sidekiq/throttler/try_again'
 
 require 'sidekiq/throttler/storage/memory'
 require 'sidekiq/throttler/storage/redis'
@@ -37,7 +38,7 @@ module Sidekiq
       end
 
       rate_limit.exceeded do |delay|
-        worker.class.perform_in(delay, *msg['args'])
+        TryAgain.reschedule(worker, msg['args'], delay)
       end
 
       rate_limit.execute

--- a/lib/sidekiq/throttler/rate_limit.rb
+++ b/lib/sidekiq/throttler/rate_limit.rb
@@ -166,6 +166,8 @@ module Sidekiq
 
       private
 
+      MUTEX = Mutex.new
+
       ##
       # Fetch the number of jobs executed by the provided `RateLimit`.
       #
@@ -174,7 +176,7 @@ module Sidekiq
       # @return [Integer]
       #   The current number of jobs executed.
       def self.count(limiter)
-        Thread.exclusive do
+        MUTEX.synchronize do
           prune(limiter)
           limiter.executions.count(limiter.key)
         end
@@ -188,7 +190,7 @@ module Sidekiq
       # @return [Integer]
       #   The current number of jobs executed.
       def self.increment(limiter)
-        Thread.exclusive do
+        MUTEX.synchronize do
           limiter.executions.append(limiter.key, Time.now)
         end
         count(limiter)

--- a/lib/sidekiq/throttler/try_again.rb
+++ b/lib/sidekiq/throttler/try_again.rb
@@ -1,0 +1,48 @@
+module Sidekiq
+  class Throttler
+    ##
+    # Handles re-scheduling a job for later if it cannot be scheduled right
+    # now.
+    class TryAgain
+
+      ##
+      # Re-schedule the job unless the worker has opted out of rescheduling
+      # throttled jobs.
+      #
+      # @param [Sidekiq::Worker] worker
+      #   The worker to rate limit.
+      #
+      # @param [Array<Object>] args
+      #   The arguments with which to schedule the worker.
+      #
+      # @param [Integer] delay
+      #   Delay in seconds to requeue job for.
+      #
+      # @return [true, false]
+      #   Whether or not the job was scheduled.
+      def self.reschedule(worker, args, delay)
+        should_reschedule = options(worker).fetch('reschedule', true)
+
+        if should_reschedule
+          worker.class.perform_in(delay, *args)
+          true
+        else
+          false
+        end
+      end
+
+      ##
+      # Returns the rate limit options for the current running worker.
+      #
+      # @param [Sidekiq::Worker] worker
+      #   The worker to rate limit.
+      #
+      # @return [{String => Float, Integer}]
+      def self.options(worker)
+        (worker.class.get_sidekiq_options['throttle'] || {}).stringify_keys
+      end
+
+      private_class_method :options
+    end # TryAgain
+  end # Throttler
+end # Sidekiq

--- a/sidekiq-throttler.gemspec
+++ b/sidekiq-throttler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
 
   gem.add_dependency 'activesupport'
-  gem.add_dependency 'sidekiq', '>= 2.5', '< 5.0'
+  gem.add_dependency 'sidekiq', '>= 2.5', '< 6.0'
 
   gem.add_development_dependency 'growl'
   gem.add_development_dependency 'guard'

--- a/sidekiq-throttler.gemspec
+++ b/sidekiq-throttler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
 
   gem.add_dependency 'activesupport'
-  gem.add_dependency 'sidekiq', '>= 2.5', '< 4.0'
+  gem.add_dependency 'sidekiq', '>= 2.5', '< 5.0'
 
   gem.add_development_dependency 'growl'
   gem.add_development_dependency 'guard'

--- a/spec/app/workers/no_reschedule_worker.rb
+++ b/spec/app/workers/no_reschedule_worker.rb
@@ -1,0 +1,7 @@
+class NoRescheduleWorker
+  include Sidekiq::Worker
+
+  sidekiq_options throttle: { threshold: 10, period: 1.minute, reschedule: false }
+
+  def perform(name); end
+end


### PR DESCRIPTION
We use `sidekiq-throttler` in combination with `sidetiq` to refresh various reports on a timer. Some of these jobs may take quite some time, and they have a rather low priority in the Sidekiq queue, so multiple jobs of the same type may get scheduled and correctly throttled by `sidekiq-throttler`, but we don't need them to be rescheduled for later - `sidetiq` will take care of this.

This PR allows rescheduling of throttled jobs to be disabled on a per-worker basis.
