### PR TITLE
Upgrade to sidekiq 4

### DIFF
--- a/sidekiq-throttler.gemspec
+++ b/sidekiq-throttler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
 
   gem.add_dependency 'activesupport'
-  gem.add_dependency 'sidekiq', '>= 2.5', '< 4.0'
+  gem.add_dependency 'sidekiq', '>= 2.5', '< 5.0'
 
   gem.add_development_dependency 'growl'
   gem.add_development_dependency 'guard'


### PR DESCRIPTION
Recreated this PR due to issues I had w/ properly forking.

Removes deprecation warning for Thread.exclusive, and updates gem specs to Sidekiq 4.

Had 0 deprecation warning for Sidekiq 4, only deprecation was the Thread.exclusive one.