### PR TITLE
Don’t package binstubs

### DIFF
--- a/sidekiq-throttler.gemspec
+++ b/sidekiq-throttler.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = %w(lib)
 


### PR DESCRIPTION
This line in is causing this gem to overwrite executables for `appraisal`, `guard`, `pry`, 
`rake`, `rspec`, and `yard`. :disappointed: 

Please merge this patch and release version 0.5.1.
